### PR TITLE
Update book list test

### DIFF
--- a/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.spec.ts
+++ b/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.spec.ts
@@ -19,7 +19,7 @@ describe('BookListComponent', () => {
 
   beforeEach(async () => {
     // Create a mock service
-    mockService = jasmine.createSpyObj<BooksService>('BooksService', ['getAllBooks']);
+    mockService = jasmine.createSpyObj<BooksService>('BooksService', ['getAllBooks', 'deleteRemoveBook', 'getBookById']);
     book = { id : 'id', title : "title", author : "author", imgUrl: "imgUrl", description: "description", isbn : "isbn", publishedDate: ""};
     mockService.getAllBooks.and.returnValue(of([book]));
     mockService.deleteRemoveBook.and.returnValue(of(true));
@@ -63,6 +63,6 @@ describe('BookListComponent', () => {
 
     // Now check if the signal was updated
     const component = fixture.componentInstance;
-    expect(component.books()).toBe([book]);
+    expect(component.books()).toEqual([book]);
   }));
 });


### PR DESCRIPTION
## Summary
- extend BooksService spy setup to include `deleteRemoveBook` and `getBookById`
- use `toEqual` matcher to compare arrays in book list spec

## Testing
- `npm test -- --watch=false` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684044a0f2e88322bc0fa2a54861f379