### PR TITLE
Update build output path in README

### DIFF
--- a/BookStoreSpa/book-store/README.md
+++ b/BookStoreSpa/book-store/README.md
@@ -34,7 +34,7 @@ To build the project run:
 ng build
 ```
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+This will compile your project and store the build artifacts in the `dist/book-store/` directory by default. The production build optimizes your application for performance and speed.
 
 ## Running unit tests
 


### PR DESCRIPTION
## Summary
- document `dist/book-store/` as the default build directory in the SPA README

## Testing
- `npm test --prefix book-store` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404499f740832287fdec49586ac9fb