### PR TITLE
Add result assertions to book handler tests

### DIFF
--- a/BookStore/BookStore.Tests/Handlers/DeleteBookHandlerTest.cs
+++ b/BookStore/BookStore.Tests/Handlers/DeleteBookHandlerTest.cs
@@ -1,5 +1,6 @@
 ﻿using BookStore.DataAccess.HandlerRequests;
 using BookStore.Domain.Interfaces;
+using FluentAssertions;
 using Moq;
 
 namespace BookStore.Tests.Handlers;
@@ -30,6 +31,8 @@ public class DeleteBookHandlerTest
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
+
+        result.Should().BeTrue();
 
         _repositoryMock.Verify(r => r.DeleteBookAsync(entityId), Times.Once);
         _unitOfWork.Verify(r => r.SaveChanges(), Times.Once);

--- a/BookStore/BookStore.Tests/Handlers/UpdateBookHandlerTest.cs
+++ b/BookStore/BookStore.Tests/Handlers/UpdateBookHandlerTest.cs
@@ -1,6 +1,7 @@
 ﻿using BookStore.Core.DTOs;
 using BookStore.DataAccess.HandlerRequests;
 using BookStore.Domain.Interfaces;
+using FluentAssertions;
 using Moq;
 
 namespace BookStore.Tests.Handlers;
@@ -32,6 +33,7 @@ public class UpdateBookHandlerTest
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
+        result.Should().BeTrue();
         _repositoryMock.Verify(r => r.UpdateBookAsync(entityId, bookDto), Times.Once);
         _unitOfWork.Verify(r => r.SaveChanges(), Times.Once);
     }


### PR DESCRIPTION
## Summary
- assert the result value in DeleteBookHandlerTest and UpdateBookHandlerTest

## Testing
- `dotnet test BookStore/BookStore.sln`

------
https://chatgpt.com/codex/tasks/task_e_684055a9bde0832282d55845f44d9a8c