### PR TITLE
Fix book list icon

### DIFF
--- a/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.html
+++ b/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.html
@@ -1,4 +1,4 @@
-<button class="btn" (click)="onCreateBook()">Add Book<i class="fa-icon fas fa-add"></i></button>  
+<button class="btn" (click)="onCreateBook()">Add Book<i class="fa-icon fas fa-plus"></i></button>
 
 @if (isFetching() && !error()) {
     <p class="fallback-text">Fetching available books...</p>


### PR DESCRIPTION
## Summary
- fix invalid `fa-add` icon in book list component

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684055a63a2c8322b2c228c61197bd3c