### PR TITLE
Fix ActivatedRoute spy typo

### DIFF
--- a/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.spec.ts
+++ b/BookStoreSpa/book-store/src/app/books/book-list/book-list.component.spec.ts
@@ -29,7 +29,7 @@ describe('BookListComponent', () => {
     mockRouter = jasmine.createSpyObj<Router>('Router', ['navigate']);
 
     // Create a mock ActivatedRoute
-    mockActivateRoute = jasmine.createSpyObj<ActivatedRoute>('ActivateRoute', ['navigate']);
+    mockActivateRoute = jasmine.createSpyObj<ActivatedRoute>('ActivatedRoute', ['navigate']);
 
     // Create a mock DestroyRef
     mockDestroyRef = jasmine.createSpyObj<DestroyRef>('DestroyRef', ['onDestroy']);


### PR DESCRIPTION
## Summary
- fix the name of the ActivatedRoute spy in `book-list.component.spec.ts`

## Testing
- `npm test` *(fails: Chrome browser not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840558e59588322a71d6aeae7c588ab