### PR TITLE
Remove unused cache from BooksService

### DIFF
--- a/BookStoreSpa/book-store/src/app/books/books.service.ts
+++ b/BookStoreSpa/book-store/src/app/books/books.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from "@angular/common/http";
-import { inject, Injectable, signal } from "@angular/core";
+import { inject, Injectable } from "@angular/core";
 
 import { Book } from "./book.model";
 import { catchError, map, throwError } from "rxjs";
@@ -10,9 +10,7 @@ import { CreateBook } from "./create-book.model";
   })
   export class BooksService {
     private httpClient = inject(HttpClient);
-    private books = signal<Book[]>([]);
 
-  loadedBooks = this.books.asReadonly();
 
   getAllBooks() {
     return this.httpClient.get<Book[]>('https://localhost:7162/api/books').pipe(


### PR DESCRIPTION
## Summary
- simplify `BooksService` by removing unused local cache

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test --silent` in `BookStoreSpa/book-store` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405a0cd8188322a630fe31c86c918f