### PR TITLE
Add environment files and configurable API base URL

### DIFF
--- a/BookStoreSpa/book-store/angular.json
+++ b/BookStoreSpa/book-store/angular.json
@@ -34,6 +34,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/BookStoreSpa/book-store/src/app/books/books.service.ts
+++ b/BookStoreSpa/book-store/src/app/books/books.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
+import { environment } from "../../environments/environment";
 
 import { Book } from "./book.model";
 import { catchError, map, throwError } from "rxjs";
@@ -8,12 +9,13 @@ import { CreateBook } from "./create-book.model";
 @Injectable({
     providedIn: 'root',
   })
-  export class BooksService {
-    private httpClient = inject(HttpClient);
+export class BooksService {
+  private httpClient = inject(HttpClient);
+  private apiBaseUrl = environment.apiBaseUrl;
 
 
   getAllBooks() {
-    return this.httpClient.get<Book[]>('https://localhost:7162/api/books').pipe(
+    return this.httpClient.get<Book[]>(`${this.apiBaseUrl}/books`).pipe(
         map((resData) => resData),
         catchError((error) => {
           return throwError(() => new Error('Something went wrong fetching the available books. Please try again later.'));
@@ -22,7 +24,7 @@ import { CreateBook } from "./create-book.model";
   }
 
   getBookById(id: string){
-    return this.httpClient.get<Book>(`https://localhost:7162/api/books/` + id).pipe(
+    return this.httpClient.get<Book>(`${this.apiBaseUrl}/books/` + id).pipe(
       map((resData) => resData),
       catchError((error) => {
         return throwError(() => new Error('Something went wrong fetching the book. Please try again later.'));
@@ -31,7 +33,7 @@ import { CreateBook } from "./create-book.model";
   }
 
   postCreateBook(book: CreateBook){
-    return this.httpClient.post<string>('https://localhost:7162/api/books/', book).pipe(
+    return this.httpClient.post<string>(`${this.apiBaseUrl}/books/`, book).pipe(
       map((resData) => resData),
       catchError((error) => {
         return throwError(() => new Error('Something went wrong creating the book. Please try again later.'));
@@ -40,7 +42,7 @@ import { CreateBook } from "./create-book.model";
   }
 
   putUpdateBook(id: string, book: CreateBook){
-    return this.httpClient.put<boolean>(`https://localhost:7162/api/books/` + id, book).pipe(
+    return this.httpClient.put<boolean>(`${this.apiBaseUrl}/books/` + id, book).pipe(
       map((resData) => resData),
       catchError((error) => {
         return throwError(() => new Error('Something went wrong updating the book. Please try again later.'));
@@ -49,7 +51,7 @@ import { CreateBook } from "./create-book.model";
   }
 
   deleteRemoveBook(id: string){
-    return this.httpClient.delete<boolean>('https://localhost:7162/api/books/' + id).pipe(
+    return this.httpClient.delete<boolean>(`${this.apiBaseUrl}/books/` + id).pipe(
       map((resData) => resData),
       catchError((error) => {
         return throwError(() => new Error('Something went wrong removing the book. Please try again later.'));

--- a/BookStoreSpa/book-store/src/environments/environment.prod.ts
+++ b/BookStoreSpa/book-store/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'https://localhost:7162/api'
+};

--- a/BookStoreSpa/book-store/src/environments/environment.ts
+++ b/BookStoreSpa/book-store/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'https://localhost:7162/api'
+};

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Entity Framework: BookDbContext defines a DbSet<Book>. Migration files exist und
 
 Unit tests: Backend tests use Moq, xUnit, and FluentAssertions (see BookStore.Tests.csproj). Angular tests use Jasmine/Karma.
 
-Angular application: The SPA is bootstrapped via main.ts and uses standalone Angular components. HTTP endpoints assume the Web API runs on https://localhost:7162/.
+Angular application: The SPA is bootstrapped via main.ts and uses standalone Angular components. API requests use the base URL defined in `src/environments/environment.ts`, which by default points to `https://localhost:7162/api`.
 
 Getting started / next steps
 


### PR DESCRIPTION
## Summary
- add Angular environment files
- replace hard-coded URLs in `BooksService` with environment value
- update Angular build config for environment file replacements
- mention environment base URL in README

## Testing
- `dotnet test BookStore/BookStore.sln --no-build` *(fails: command not found)*
- `npm test` in `BookStoreSpa/book-store` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405ca7b2c88322a5ffd77256a2530d